### PR TITLE
fix: ws-logs in non-tui mode

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -82,8 +82,8 @@ pub (crate) async fn run(globally_shared_state: crate::global_state::GlobalState
             .route("/script.js", axum::routing::get(script))
 
             
-            // WEBSOCKET ROUTE
-            .route("/ws", axum::routing::get(ws_handler).with_state(websocket_state.clone()))
+            // WEBSOCKET ROUTE FOR LOGS
+            .route("/ws/live_logs", axum::routing::get(ws_log_messages_handler).with_state(websocket_state.clone()))
 
             
         ; 
@@ -119,7 +119,7 @@ async fn script() -> impl IntoResponse {
     tag = "Logs",
     path = "/live_logs",
 )]
-async fn ws_handler(
+async fn ws_log_messages_handler(
     ws: WebSocketUpgrade,
     user_agent: Option<axum_extra::TypedHeader<axum_extra::headers::UserAgent>>,
     axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<SocketAddr> ,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,190 @@
+use std::collections::VecDeque;
+use std::{collections::HashMap, sync::Arc};
+
+use std::sync::Mutex;
+use tracing::Subscriber;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+#[derive(Clone)]
+pub (crate) struct LogMsg {
+    pub (crate) msg: String,
+    pub (crate) lvl: tracing::Level,
+    pub (crate) src: String,
+    pub (crate) thread: Option<String>
+}
+
+
+
+struct LogVisitor {
+    fields: HashMap<String, String>,
+}
+
+impl tracing::field::Visit for LogVisitor {
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {        
+        self.fields.insert(field.name().to_string(), format!("{:?}",value));
+    }
+
+}
+impl LogVisitor {
+    fn new() -> Self {
+        LogVisitor {
+            fields: HashMap::new(),
+        }
+    }
+    fn result(self) -> String {
+        self.fields
+            .iter()
+            .map(|(_key, value)| format!("{}", value))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+pub struct NonTuiLoggerLayer {
+    pub broadcaster: tokio::sync::broadcast::Sender<String>
+}
+impl<S: Subscriber> tracing_subscriber::Layer<S> for NonTuiLoggerLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+
+        let metadata = event.metadata();
+        let target = metadata.target();
+        
+        // Create a visitor to format the fields of the event.
+        let mut visitor = LogVisitor::new();
+        event.record(&mut visitor);
+        
+        let mut msg =  visitor.result();
+        let mut src = String::new();
+
+        if msg.starts_with("[") && msg.contains("]") {
+            let end = msg.find("]").unwrap_or_default();
+            src = msg[1..end].to_string().trim().to_string();
+            msg = msg[end+1..].to_string().trim().to_string();
+        }
+
+        if src.is_empty() {
+            if !target.ends_with("proc_host") {
+                src = target.into();
+            }
+        }
+
+        let current_thread = std::thread::current();
+        let current_thread_name = current_thread.name().and_then(|x|Some(x.to_string())).unwrap_or(format!("HAH!"));
+        let mut skip_src = false;
+        let thread_name = if current_thread_name == "tokio-runtime-worker" { 
+            skip_src = true;
+            Some(src.to_string()) 
+        } else { 
+            Some(current_thread_name) 
+        };
+
+        let log_message = LogMsg {
+            thread: thread_name.clone(),
+            lvl: metadata.level().clone(),
+            src: if skip_src { "".into() } else {src},
+            msg,
+        };
+        
+        _ = self.broadcaster.send(serde_json::to_string_pretty(&log_message).expect("should always be possible to serialize log messages"));
+
+    
+    }
+}
+
+
+
+
+pub struct SharedLogBuffer {
+    pub (crate) logs: VecDeque<LogMsg>,
+    pub (crate) limit : Option<usize>
+}
+
+impl SharedLogBuffer {
+    
+    pub fn new() -> Self {
+        SharedLogBuffer {
+            logs: VecDeque::new(),
+            limit: Some(500)
+        }
+    }
+
+    fn push(&mut self, message: LogMsg) {
+
+        self.logs.push_back(message);
+        match self.limit {
+            Some(x) => {
+                while self.logs.len() > x {
+                    self.logs.pop_front();
+                }
+            },
+            None => {},
+        }
+        
+    }
+
+
+}
+
+pub struct TuiLoggerLayer {
+    pub log_buffer: Arc<Mutex<SharedLogBuffer>>,
+    pub broadcaster: tokio::sync::broadcast::Sender<String>
+}
+
+impl<S: Subscriber> Layer<S> for TuiLoggerLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+
+
+        let target = metadata.target();
+        
+        // Create a visitor to format the fields of the event.
+        let mut visitor = LogVisitor::new();
+        event.record(&mut visitor);
+        
+        let mut msg =  visitor.result();
+        let mut src = String::new();
+        
+        if msg.starts_with("[") && msg.contains("]") {
+            let end = msg.find("]").unwrap_or_default();
+            src = msg[1..end].to_string().trim().to_string();
+            msg = msg[end+1..].to_string().trim().to_string();
+        }
+
+        if src.is_empty() {
+            if !target.ends_with("proc_host") {
+                src = target.into();
+            }
+            
+        }
+
+        let current_thread = std::thread::current();
+        let current_thread_name = current_thread.name().and_then(|x|Some(x.to_string())).unwrap_or(format!("HAH!"));
+        let mut skip_src = false;
+        let thread_name = if current_thread_name == "tokio-runtime-worker" { 
+            skip_src = true;
+            Some(src.to_string()) 
+        } else { 
+            Some(current_thread_name) 
+        };
+
+        let log_message = LogMsg {
+            thread: thread_name.clone(),
+            lvl: metadata.level().clone(),
+            src: if skip_src { "".into() } else {src},
+            msg,
+        };
+        
+        _ = self.broadcaster.send(serde_json::to_string_pretty(&log_message).expect("should always be possible to serialize log messages"));
+        let mut buffer = self.log_buffer.lock().expect("must always be able to lock log buffer");
+        buffer.push(log_message.clone());
+        
+    
+    }
+}
+

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,14 +4,14 @@ use ratatui::text::Line;
 use ratatui::widgets::{BorderType, Cell, List, ListItem, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table};
 use tokio::sync::RwLockWriteGuard;
 use tokio::task;
-use tracing::{Level, Subscriber};
-use tracing_subscriber::{Layer, EnvFilter};
-use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing::Level;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
 use std::borrow::BorrowMut;
-use std::collections::{HashMap, VecDeque};
 use std::io::Stdout;
 use crate::global_state::GlobalState;
-
+use crate::logging::SharedLogBuffer;
+use crate::logging::LogMsg;
 use crate::types::app_state::*;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -38,14 +38,6 @@ use ratatui::{
     Terminal,
 };
 
-#[derive(Clone)]
-struct LogMsg {
-    msg: String,
-    lvl: Level,
-    src: String,
-    thread: Option<String>
-}
-
 impl serde::Serialize for LogMsg {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -57,126 +49,6 @@ impl serde::Serialize for LogMsg {
         s.serialize_field("thread", &self.thread.as_ref().unwrap_or(&"".to_string()))?;
         s.end()
 
-    }
-}
-
-struct SharedLogBuffer {
-    pub (crate) logs: VecDeque<LogMsg>,
-    pub (crate) limit : Option<usize>
-}
-
-impl SharedLogBuffer {
-    
-    fn new() -> Self {
-        SharedLogBuffer {
-            logs: VecDeque::new(),
-            limit: Some(500)
-        }
-    }
-
-    fn push(&mut self, message: LogMsg) {
-
-        self.logs.push_back(message);
-        match self.limit {
-            Some(x) => {
-                while self.logs.len() > x {
-                    self.logs.pop_front();
-                }
-            },
-            None => {},
-        }
-        
-    }
-
-
-}
-
-struct LogVisitor {
-    fields: HashMap<String, String>,
-}
-
-impl tracing::field::Visit for LogVisitor {
-
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.fields.insert(field.name().to_string(), value.to_string());
-    }
-
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {        
-        self.fields.insert(field.name().to_string(), format!("{:?}",value));
-    }
-
-}
-impl LogVisitor {
-    fn new() -> Self {
-        LogVisitor {
-            fields: HashMap::new(),
-        }
-    }
-    fn result(self) -> String {
-        self.fields
-            .iter()
-            .map(|(_key, value)| format!("{}", value))
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-}
-
-struct TuiLoggerLayer {
-    log_buffer: Arc<Mutex<SharedLogBuffer>>,
-    broadcaster: tokio::sync::broadcast::Sender<String>
-}
-
-impl<S: Subscriber> Layer<S> for TuiLoggerLayer {
-    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-        let metadata = event.metadata();
-
-
-        let target = metadata.target();
-        
-        // Create a visitor to format the fields of the event.
-        let mut visitor = LogVisitor::new();
-        event.record(&mut visitor);
-        
-        let mut msg =  visitor.result();
-        let mut src = String::new();
-        
-
-
-        if msg.starts_with("[") && msg.contains("]") {
-            let end = msg.find("]").unwrap_or_default();
-            src = msg[1..end].to_string().trim().to_string();
-            msg = msg[end+1..].to_string().trim().to_string();
-        }
-
-        if src.is_empty() {
-            if !target.ends_with("proc_host") {
-                src = target.into();
-            }
-            
-        }
-
-        let current_thread = std::thread::current();
-        let current_thread_name = current_thread.name().and_then(|x|Some(x.to_string())).unwrap_or(format!("HAH!"));
-        let mut skip_src = false;
-        let thread_name = if current_thread_name == "tokio-runtime-worker" { 
-            skip_src = true;
-            Some(src.to_string()) 
-        } else { 
-            Some(current_thread_name) 
-        };
-
-        let log_message = LogMsg {
-            thread: thread_name.clone(),
-            lvl: metadata.level().clone(),
-            src: if skip_src { "".into() } else {src},
-            msg,
-        };
-        
-        _ = self.broadcaster.send(serde_json::to_string_pretty(&log_message).expect("should always be possible to serialize log messages"));
-        let mut buffer = self.log_buffer.lock().expect("must always be able to lock log buffer");
-        buffer.push(log_message.clone());
-        
-    
     }
 }
 
@@ -194,7 +66,7 @@ pub (crate) async fn run(
 ) {
     
     let log_buffer = Arc::new(Mutex::new(SharedLogBuffer::new()));
-    let layer = TuiLoggerLayer { log_buffer: log_buffer.clone(), broadcaster: trace_msg_broadcaster };
+    let layer = crate::logging::TuiLoggerLayer { log_buffer: log_buffer.clone(), broadcaster: trace_msg_broadcaster };
 
     let subscriber = tracing_subscriber::registry()
         .with(filter).with(layer);


### PR DESCRIPTION
When starting in non-tui mode, we did not use our custom layer for submitting log messages to the ws broadcaster.. thus no messages were received by the clients...  

This PR adds a new layer for non-tui mode (and uses it) and moves most code related to this in to a separate logging.rs file instead of it cluttering up main and tui.rs..  

*note: this pr also changes the endpoint for logs from /ws to /ws/live_logs, as we will want to provide different websocket endpoints (for example 'stats')*