### PR TITLE
Hot reload

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
                     "kind": "bin"
                 }
             },
-            "args": ["odd-box-example-config.toml"],
+            "args": ["odd-box.toml","--tui=false"],
             "cwd": "${workspaceFolder}"
         }
     ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -487,6 +487,12 @@ dependencies = [
  "syn 2.0.77",
  "which 4.4.2",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -738,6 +744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,9 +764,9 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "crossterm_winapi",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -1102,6 +1117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1188,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1614,6 +1650,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1743,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,8 +1796,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1836,6 +1913,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
@@ -1876,7 +1965,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1891,6 +1980,25 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1984,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "odd-box"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -2012,6 +2120,7 @@ dependencies = [
  "markdown",
  "memchr",
  "mime_guess",
+ "notify",
  "once_cell",
  "p256",
  "ratatui",
@@ -2073,7 +2182,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2473,7 +2582,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -2508,7 +2617,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2714,7 +2823,7 @@ version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2859,7 +2968,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3064,7 +3173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -3313,7 +3422,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3461,7 +3570,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "odd-box"
 description = "dead simple reverse proxy server"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = ["Olof Blomqvist <olof@twnet.se>"]
 repository = "https://github.com/OlofBlomqvist/odd-box"
@@ -75,6 +75,7 @@ mime_guess = "2.0.5"
 markdown = "1.0.0-alpha.21"
 flate2 = "1.0.34"
 once_cell = "1.20.2"
+notify = "6.1.1"
 #rsa = "0.9.6"
 # ===============================================================
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ but there are more ways to install odd-box if you so wish :-)
 
 ```zsh
 brew tap OlofBlomqvist/repo
-brew install oddbox
+brew install odd-box
 ```
 
 - [Cargo install](https://doc.rust-lang.org/cargo/getting-started/installation.html)
@@ -228,15 +228,37 @@ There are more options than the ones shown here; these are the most commonly use
     - ``https``: (Optional) Set to true if the process uses HTTP (TLS)
     - ``enable_lets_encrypt``: (Optional) Set to true to enable lets-encrypt to be used for this site.
 
+4. Adding dir servers: for serving static websites or files. Supports directory indexing and markdown rendering.
+    ```toml
+    [[dir_server]]
+    host_name = "dir.localtest.me"
+    dir = "$cfg_dir"
+    enable_directory_browsing = true
+    render_markdown = true
+    ```
 
 
 
-#### Getting Started
+## Getting Started
 
-To get started quickly, simply copy the [minimal example configuration file](https://github.com/OlofBlomqvist/odd-box/blob/main/odd-box-example-config-minimal.toml), modify the relevant sections to add your remote targets or hosted processes, and run odd-box with your configuration file.
+### Creating a config file
 
+You can generate a basic "odd-box.toml" config file to get started:
+```
+odd-box --init 
+```
 
-## Upgrading odd-box
+From here, you can either open up the config file in your favorite editor, or just run odd-box and open your browser going to http://localhost:1234 where you can configure odd-box thru its web-interface.
+
+### Lets encrypt
+
+Lets encrypt support works by creating a virtual file that can be used for proving ownership of a domain name. No support exists for the DNS auth mode.
+
+You will need to have odd-box running on a server with a public IP and a DNS record pointing to it. Port 80 and 443 are both used and need to be open.
+
+Certificates are automatically renewed when they have less than 30 days left of validity.
+
+### Upgrading
 
 If you are not using a package manager such as homebrew to manage your odd-box installation, you can either manually download new versions from the github release section or use the built in command for doing the same:
 ```odd-box --update```

--- a/odd-box-schema-v2.1.json
+++ b/odd-box-schema-v2.1.json
@@ -3,12 +3,11 @@
   "title": "OddBoxV2Config",
   "type": "object",
   "required": [
-    "env_vars",
-    "port_range_start",
     "version"
   ],
   "properties": {
     "admin_api_port": {
+      "description": "The port for the admin api. If this is not set, the admin api will not be started. This setting also enabled the web-ui on the same port.",
       "type": [
         "integer",
         "null"
@@ -49,6 +48,8 @@
       }
     },
     "env_vars": {
+      "description": "Environment variables configured here will be made available to all processes started by odd-box.",
+      "default": [],
       "type": "array",
       "items": {
         "$ref": "#/definitions/EnvVar"
@@ -64,6 +65,7 @@
       }
     },
     "http_port": {
+      "description": "The port on which to listen for http requests. Defaults to 8080.",
       "default": 8080,
       "type": [
         "integer",
@@ -80,6 +82,7 @@
       "format": "ip"
     },
     "lets_encrypt_account_email": {
+      "description": "If you want to use lets-encrypt for generating certificates automatically for your sites",
       "type": [
         "string",
         "null"
@@ -96,13 +99,9 @@
         }
       ]
     },
-    "path": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "port_range_start": {
+      "description": "The port range start is used to determine which ports to use for hosted processes.",
+      "default": 4200,
       "type": "integer",
       "format": "uint16",
       "minimum": 0.0
@@ -123,6 +122,7 @@
       ]
     },
     "tls_port": {
+      "description": "The port on which to listen for https requests. Defaults to 4343.",
       "default": 4343,
       "type": [
         "integer",
@@ -132,7 +132,12 @@
       "minimum": 0.0
     },
     "version": {
-      "$ref": "#/definitions/OddBoxConfigVersion"
+      "description": "The schema version - you do not normally need to set this, it is set automatically when you save the configuration.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OddBoxConfigVersion"
+        }
+      ]
     }
   },
   "definitions": {
@@ -203,6 +208,18 @@
         "host_name": {
           "description": "This is the hostname that the site will respond to.",
           "type": "string"
+        },
+        "redirect_to_https": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "render_markdown": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },
@@ -260,6 +277,7 @@
       ],
       "properties": {
         "args": {
+          "description": "Arguments to pass to the binary when starting it.",
           "type": [
             "array",
             "null"
@@ -276,6 +294,7 @@
           ]
         },
         "bin": {
+          "description": "The binary to start. This can be a path to a binary or a command that is in the PATH.",
           "type": "string"
         },
         "capture_subdomains": {
@@ -286,6 +305,7 @@
           ]
         },
         "dir": {
+          "description": "Working directory for the process. If this is not set, the current working directory will be used.",
           "type": [
             "string",
             "null"
@@ -306,6 +326,7 @@
           ]
         },
         "env_vars": {
+          "description": "Environment variables to set for the process.",
           "type": [
             "array",
             "null"
@@ -348,6 +369,7 @@
           ]
         },
         "log_format": {
+          "description": "The log format to use for this site. If this is not set, the default log format will be used. Currently the only supported log formats are \"standard\" and \"dotnet\".",
           "anyOf": [
             {
               "$ref": "#/definitions/LogFormat"
@@ -436,6 +458,13 @@
         },
         "host_name": {
           "type": "string"
+        },
+        "keep_original_host_header": {
+          "description": "If you wish to pass along the incoming request host header to the backend rather than the host name of the backends. Defaults to false.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     }

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -459,14 +459,10 @@ impl ConfigWrapper {
             hosted_site_configs.retain(|x| x.host_name != item.host_name);
             hosted_site_configs.retain(|x| x.host_name != hostname);
             hosted_site_configs.push(item.clone());            
-        } else {
+        } else {    
             self.hosted_process = Some(vec![item.clone()]);
         }
         self.write_to_disk()
-       
-    
-       
-    
     }
 
     // todo: work with the wrapper dashmap instead

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -10,6 +10,7 @@ use v2::{DirServer, FullyResolvedInProcessSiteConfig};
 pub mod legacy;
 pub mod v1;
 pub mod v2;
+pub mod reload;
 
 pub trait OddBoxConfiguration<T> { 
     fn example() -> T;
@@ -148,7 +149,8 @@ pub struct ConfigWrapper {
     internal_configuration : v2::OddBoxV2Config,
     pub remote_sites: DashMap<String, v2::RemoteSiteConfig>,
     pub hosted_processes: DashMap<String, v2::InProcessSiteConfig>,
-    pub wrapper_cache_map_is_dirty: bool
+    pub wrapper_cache_map_is_dirty: bool,
+    pub internal_version: u64
 }
 
 
@@ -189,6 +191,7 @@ impl ConfigWrapper {
         }
 
         ConfigWrapper {
+            internal_version: 0,
             internal_configuration: config,
             remote_sites,
             hosted_processes,
@@ -197,7 +200,7 @@ impl ConfigWrapper {
     }
 
     // re-populate the dashmaps from the internal configuration vectors
-    pub fn reload(&mut self) {
+    pub fn reload_dashmaps(&mut self) {
         
         self.hosted_processes.clear();
         self.remote_sites.clear();
@@ -366,7 +369,7 @@ impl ConfigWrapper {
     }
     
 
-    pub fn get_parent_path(&mut self) -> anyhow::Result<String> {
+    pub fn get_parent_path(&self) -> anyhow::Result<String> {
         // todo - use cache and clear on path change
         // if let Some(pre_resolved) = &self.1 {
         //     return Ok(pre_resolved.to_string())
@@ -450,54 +453,15 @@ impl ConfigWrapper {
     
      // ---> port-mapping...
     // todo: work with the wrapper dashmap instead
-    pub async fn add_or_replace_hosted_process(&mut self,hostname:&str,item:crate::InProcessSiteConfig,state:Arc<crate::GlobalState>) -> anyhow::Result<()> {
+    pub async fn add_or_replace_hosted_process(&mut self,hostname:&str,item:crate::InProcessSiteConfig,_state:Arc<crate::GlobalState>) -> anyhow::Result<()> {
         
         if let Some(hosted_site_configs) = &mut self.hosted_process {
-            
-            for x in hosted_site_configs.iter_mut() {
-                if hostname == x.host_name {
-
-
-
-                    let (tx,mut rx) = tokio::sync::mpsc::channel(1);
-
-                    state.broadcaster.send(crate::http_proxy::ProcMessage::Delete(hostname.into(),tx))?;
-                            
-                    if rx.recv().await == Some(0) {
-                        // when we get this message, we know that the process has been stopped
-                        // and that the loop has been exited as well.
-                        tracing::debug!("Received a confirmation that the process was deleted");
-                    } else {
-                        tracing::debug!("Failed to receive a confirmation that the process was deleted. This is a bug in odd-box.");
-                    };
-
-
-                    break;
-                }
-            };
-
-            tracing::debug!("Pushing a new process to the configuration thru the admin api");
             hosted_site_configs.retain(|x| x.host_name != item.host_name);
             hosted_site_configs.retain(|x| x.host_name != hostname);
-            hosted_site_configs.push(item.clone());
-            
-
-            let resolved_proc = self.resolve_process_configuration(&item)?;
-
-            tokio::task::spawn(crate::proc_host::host(
-                resolved_proc,
-                state.broadcaster.subscribe(),
-                state.clone(),
-            ));
-            tracing::trace!("Spawned a new thread for site: {:?}",hostname);
-            
-            let guard = &state.app_state.site_status_map;
-            guard.retain(|k,_v| k != hostname);
-            guard.insert(item.host_name, crate::types::app_state::ProcState::Stopped);    
+            hosted_site_configs.push(item.clone());            
+        } else {
+            self.hosted_process = Some(vec![item.clone()]);
         }
-    
-        self.reload();
-    
         self.write_to_disk()
        
     
@@ -506,29 +470,23 @@ impl ConfigWrapper {
     }
 
     // todo: work with the wrapper dashmap instead
-    pub async fn add_or_replace_dir_site(&mut self,hostname:&str,item:DirServer,state:Arc<crate::GlobalState>) -> anyhow::Result<()> {
+    pub async fn add_or_replace_dir_site(&mut self,old_hostname:&str,item:DirServer,_state:Arc<crate::GlobalState>) -> anyhow::Result<()> {
         
 
         if let Some(sites) = self.dir_server.as_mut() {
             // out with the old, in with the new
-            sites.retain(|x| x.host_name != hostname);
+            sites.retain(|x| x.host_name != old_hostname);
             sites.retain(|x| x.host_name != item.host_name);
             sites.push(item.clone());
-
-            // same as above but for the TUI state
-            let map_guard = &state.app_state.site_status_map;
-            map_guard.retain(|k,_v| *k != item.host_name);
-            map_guard.retain(|k,_v| k != hostname);
-            map_guard.insert(item.host_name, crate::types::app_state::ProcState::Dynamic);
+        } else {
+            self.dir_server = Some(vec![item.clone()]);
         }
-    
-        self.reload();
         self.write_to_disk()
     
     }
     
      // todo: work with the wrapper dashmap instead
-     pub async fn add_or_replace_remote_site(&mut self,hostname:&str,item:crate::RemoteSiteConfig,state:Arc<crate::GlobalState>) -> anyhow::Result<()> {
+     pub async fn add_or_replace_remote_site(&mut self,hostname:&str,item:crate::RemoteSiteConfig,_state:Arc<crate::GlobalState>) -> anyhow::Result<()> {
         
 
         if let Some(sites) = self.remote_target.as_mut() {
@@ -536,15 +494,9 @@ impl ConfigWrapper {
             sites.retain(|x| x.host_name != hostname);
             sites.retain(|x| x.host_name != item.host_name);
             sites.push(item.clone());
-
-            // same as above but for the TUI state
-            let map_guard = &state.app_state.site_status_map;
-            map_guard.retain(|k,_v| *k != item.host_name);
-            map_guard.retain(|k,_v| k != hostname);
-            map_guard.insert(item.host_name, crate::types::app_state::ProcState::Remote);
+        } else {
+            self.remote_target = Some(vec![item.clone()]);
         }
-    
-        self.reload();
         self.write_to_disk()
     
     }
@@ -621,33 +573,9 @@ impl ConfigWrapper {
         }
     }
 
+    pub fn resolve_dir_server_configuration(&self,item:&DirServer) -> anyhow::Result<DirServer> {
 
-    // this MUST be called by proc_host prior to starting a process in order to resolve all variables.
-    // it is done this way in order to avoid changing the global state of the configuration in to the resolved state
-    // since that would then be saved to disk and we would lose the original configuration with dynamic variables
-    // making configuration files less portable.
-    // todo - cache resolved configurations by hash?
-    // todo: work with the wrapper dashmap instead
-    pub fn resolve_process_configuration(&mut self,proc:&crate::InProcessSiteConfig) -> anyhow::Result<crate::FullyResolvedInProcessSiteConfig> {
-
-        let mut resolved_proc = crate::FullyResolvedInProcessSiteConfig {
-            excluded_from_start_all: proc.exclude_from_start_all.unwrap_or(false),
-            proc_id: proc.get_id().clone(),
-            active_port: proc.active_port,
-            disable_tcp_tunnel_mode: proc.disable_tcp_tunnel_mode,
-            hints: proc.hints.clone(),
-            host_name: proc.host_name.clone(),
-            dir: proc.dir.clone(),
-            bin: proc.bin.clone(),
-            args: proc.args.clone(),
-            env_vars: proc.env_vars.clone(),
-            log_format: proc.log_format.clone(),
-            auto_start: proc.auto_start,
-            port: proc.port,
-            https: proc.https,
-            capture_subdomains: proc.capture_subdomains,
-            forward_subdomains: proc.forward_subdomains
-        };
+        let mut resolved_dir_server = item.clone();
 
         let resolved_home_dir_path = dirs::home_dir().ok_or(anyhow::anyhow!(String::from("Failed to resolve home directory.")))?;
         let resolved_home_dir_str = resolved_home_dir_path.to_str().ok_or(anyhow::anyhow!(String::from("Failed to parse home directory.")))?;
@@ -683,6 +611,90 @@ impl ConfigWrapper {
             canonicalized_with_vars
         } else {
             "$root_dir".to_string()
+        };
+
+        let resolved_home_dir_path = dirs::home_dir().ok_or(anyhow::anyhow!(String::from("Failed to resolve home directory.")))?;
+        let resolved_home_dir_str = resolved_home_dir_path.to_str().ok_or(anyhow::anyhow!(String::from("Failed to parse home directory.")))?;
+        
+        let with_vars = |x:&str| -> String {
+            x.replace("$root_dir", &root_dir)
+            .replace("$cfg_dir", &cfg_dir)
+            .replace("~", resolved_home_dir_str)
+        };
+
+        resolved_dir_server.dir = with_vars(&item.dir);
+
+        Ok(resolved_dir_server)
+
+    }
+
+
+
+    // this MUST be called by proc_host prior to starting a process in order to resolve all variables.
+    // it is done this way in order to avoid changing the global state of the configuration in to the resolved state
+    // since that would then be saved to disk and we would lose the original configuration with dynamic variables
+    // making configuration files less portable.
+    // todo: work with the wrapper dashmap instead
+    // note: we dont cache this right now but perhaps we should...
+    //       the reason it's not cached is that the configuration may change at runtime
+    //       and we'd need to invalidate this cache every time the global configuration changes.
+    //       perhaps work on this later.
+    pub fn resolve_process_configuration(&mut self,proc:&crate::InProcessSiteConfig) -> anyhow::Result<crate::FullyResolvedInProcessSiteConfig> {
+
+        let mut resolved_proc = crate::FullyResolvedInProcessSiteConfig {
+            excluded_from_start_all: proc.exclude_from_start_all.unwrap_or(false),
+            proc_id: proc.get_id().clone(),
+            active_port: proc.active_port,
+            disable_tcp_tunnel_mode: proc.disable_tcp_tunnel_mode,
+            hints: proc.hints.clone(),
+            host_name: proc.host_name.clone(),
+            dir: proc.dir.clone(),
+            bin: proc.bin.clone(),
+            args: proc.args.clone(),
+            env_vars: proc.env_vars.clone(),
+            log_format: proc.log_format.clone(),
+            auto_start: proc.auto_start,
+            port: proc.port,
+            https: proc.https,
+            capture_subdomains: proc.capture_subdomains,
+            forward_subdomains: proc.forward_subdomains
+        };
+
+        let resolved_home_dir_path = dirs::home_dir().ok_or(anyhow::anyhow!(String::from("Failed to resolve home directory.")))?;
+        let resolved_home_dir_str = resolved_home_dir_path.to_str().ok_or(anyhow::anyhow!(String::from("Failed to parse home directory.")))?;
+
+        //tracing::info!("Resolved home directory: {}",&resolved_home_dir_str);
+
+        let cfg_dir = self.get_parent_path()?;
+
+
+        let root_dir = if let Some(rd) = &self.root_dir {
+            
+            if rd.contains("$root_dir") {
+                anyhow::bail!("it is clearly not a good idea to use $root_dir in the configuration of root dir...")
+            }
+
+            let rd_with_vars_replaced = rd
+                .replace("$cfg_dir", &cfg_dir)
+                .replace("~", resolved_home_dir_str);
+
+            let canonicalized_with_vars = 
+                match std::fs::canonicalize(rd_with_vars_replaced.clone()) {
+                    Ok(resolved_path) => {
+                        resolved_path.display().to_string()
+                            // we dont want to use ext path def on windows
+                            .replace("\\\\?\\", "")
+                    }
+                    Err(e) => {
+                        anyhow::bail!(format!("root_dir item in configuration ({rd}) resolved to this: '{rd_with_vars_replaced}' - error: {}", e));
+                    }
+                };
+            
+            //tracing::debug!("$root_dir resolved to: {rd}");
+            canonicalized_with_vars
+        } else {
+            let current_directory = std::env::current_dir()?;
+            current_directory.display().to_string()
         };
 
         let resolved_home_dir_path = dirs::home_dir().ok_or(anyhow::anyhow!(String::from("Failed to resolve home directory.")))?;

--- a/src/configuration/reload.rs
+++ b/src/configuration/reload.rs
@@ -1,0 +1,163 @@
+// this module is responsible for reloading the configuration file at runtime (hot-reload)
+
+use std::{io::Read, sync::Arc, time::Duration};
+use anyhow::{bail, Result};
+use tracing::{info, trace, warn};
+
+use crate::{configuration::v2::{DirServer, InProcessSiteConfig, RemoteSiteConfig}, global_state::GlobalState, proc_host, types::app_state::ProcState};
+
+use super::{ConfigWrapper, OddBoxConfig};
+
+pub async fn reload_from_disk(global_state: Arc<GlobalState>) -> Result<()> {
+ 
+    trace!("Reading configuration from disk");
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let active_configuration = { global_state.config.read().await.clone() };
+    let mut file = std::fs::File::open(&active_configuration.path.clone().ok_or(anyhow::Error::msg("cfg path not valid"))?)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;    
+    drop(file);
+    let (mut new_configuration,_original_version) = 
+        match OddBoxConfig::parse(&contents) {
+            Ok(configuration) => {
+                let (a,b) = 
+                    configuration
+                        .try_upgrade_to_latest_version()
+                        .expect("configuration upgrade failed. this is a bug in odd-box");
+                (ConfigWrapper::new(a),b)
+            },
+            Err(e) => anyhow::bail!(e),
+        };
+    
+    new_configuration.internal_version = active_configuration.internal_version + 1;
+
+
+    new_configuration.is_valid()?;
+    new_configuration.set_disk_path(&active_configuration.path.clone().ok_or(anyhow::Error::msg("cfg path not valid"))?)?;
+    
+    if new_configuration.eq(&active_configuration) {
+        trace!("Configuration has not changed, skipping reload");
+        return Ok(());
+    } else {
+        warn!("Configuration has changed on disk, reloading");
+    }
+
+    let has_changed_le_mail = new_configuration.lets_encrypt_account_email != active_configuration.lets_encrypt_account_email;
+    
+
+    let mut all_cloned_new_procs : Vec<InProcessSiteConfig> = new_configuration.hosted_process.iter().flatten().cloned().collect();
+    let mut abort = false;
+
+    // lets filter out any processes that are already running and have the same configuration..
+    // we dont need to restart them..
+    let cloned_modified_procs : Vec<InProcessSiteConfig> = all_cloned_new_procs.iter_mut().filter_map(|x|{
+        let existing = crate::PROC_THREAD_MAP.iter().find(|y|y.config.host_name == x.host_name);
+        if let Some(existing) = existing {
+            if let Ok(mut r) = new_configuration.resolve_process_configuration(&x) {
+                r.proc_id = existing.config.proc_id.clone();
+                r.active_port = existing.config.active_port;
+                x.set_id(r.proc_id.clone());
+                if existing.config.eq(&r) {
+                    warn!("Process {} has not changed, skipping restart",x.host_name);
+                    return None;
+                } else {
+                    info!("Process {} has changed, will restart",x.host_name);
+                    return Some(x.clone());
+                }
+            } else {
+
+                warn!("Failed to resolve process configuration for process {}",x.host_name);
+                abort = true;
+                return None;
+            }
+        }
+        return Some(x.clone());
+    }).collect();
+
+    new_configuration.hosted_process = Some(all_cloned_new_procs);
+
+    if abort {
+        bail!("Failed to resolve process configuration for some processes");
+    }
+
+    let cloned_rems : Vec<RemoteSiteConfig> = new_configuration.remote_target.iter().flatten().cloned().collect();
+    let cloned_dirs : Vec<DirServer> = new_configuration.dir_server.iter().flatten().cloned().collect();
+    
+    new_configuration.reload_dashmaps();
+
+    for mut x in crate::PROC_THREAD_MAP.iter_mut() {
+        if cloned_modified_procs.iter().any(|p|p.host_name==x.config.host_name) {
+            info!("Marking process {} for removal as it has changed",x.config.host_name);
+            x.marked_for_removal = true; 
+        } else if new_configuration.hosted_process.iter().flatten().any(|p|p.host_name==x.config.host_name) {
+            // ok so this process is still in the new configuration, but it has not changed
+            info!("Process {} is still in the new configuration, but has not changed",x.config.host_name);
+        } else {
+            info!("Marking process {} for removal as it is no longer in the configuration",x.config.host_name);
+            x.marked_for_removal = true;   
+        }
+         
+    }
+
+    loop {
+        {
+            if crate::PROC_THREAD_MAP.iter().any(|x|x.marked_for_removal) {
+                info!("Waiting for all processes to exit before starting new ones");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        }
+        break;
+    }
+
+   
+    global_state.app_state.site_status_map.clear();
+
+    // Add any remotes to the site list
+    for x in cloned_rems {
+        global_state.app_state.site_status_map.insert(x.host_name.to_owned(), ProcState::Remote);
+    }
+
+    // Add any hosted dirs to site list
+    for x in cloned_dirs {
+        global_state.app_state.site_status_map.insert(x.host_name.to_owned(), ProcState::Dynamic);
+    }
+
+   
+    // And spawn the hosted process worker loops
+    for x in cloned_modified_procs {
+        match new_configuration.resolve_process_configuration(&x) {
+            Ok(x) => {
+                tokio::task::spawn(proc_host::host(
+                    x,
+                    global_state.broadcaster.subscribe(),
+                    global_state.clone(),
+                ));
+            }
+            Err(e) => bail!("Failed to resolve process configuration for:\n=====================================================\n{:?}.\n=====================================================\n\nThe error was: {:?}",x,e)
+        }
+    }
+
+
+    let mut guard = global_state.config.write().await;
+    *guard = new_configuration;
+    drop(guard);
+
+
+
+    if has_changed_le_mail {
+        if active_configuration.lets_encrypt_account_email.is_some() {
+            global_state.cert_resolver.enable_lets_encrypt();
+        } else {
+            global_state.cert_resolver.disable_lets_encrypt();
+        }
+    }
+
+    
+    info!("Configuration reloaded successfully, invalidading caches.");
+    global_state.invalidate_cache();
+    info!("Configuration swap complete - caches invalidated.");
+    Ok(())
+}

--- a/src/configuration/v2.rs
+++ b/src/configuration/v2.rs
@@ -139,7 +139,9 @@ impl PartialEq for InProcessSiteConfig {
         self.port == other.port &&
         self.https == other.https &&
         compare_option_bool(self.capture_subdomains, other.capture_subdomains) &&
-        compare_option_bool(self.forward_subdomains, other.forward_subdomains)
+        compare_option_bool(self.forward_subdomains, other.forward_subdomains) &&
+        compare_option_bool(self.exclude_from_start_all, other.exclude_from_start_all)
+        
     }
 }
 
@@ -418,6 +420,12 @@ impl crate::configuration::OddBoxConfiguration<OddBoxV2Config> for OddBoxV2Confi
                 if let Some(true) = s.enable_lets_encrypt {
                     formatted_toml.push(format!("enable_lets_encrypt = true"));
                 }
+                if let Some(true) = s.render_markdown {
+                    formatted_toml.push(format!("render_markdown = true"));
+                }
+                if let Some(true) = s.redirect_to_https {
+                    formatted_toml.push(format!("redirect_to_https = true"));
+                }
             }
         }
         
@@ -495,7 +503,10 @@ impl crate::configuration::OddBoxConfiguration<OddBoxV2Config> for OddBoxV2Confi
                 if let Some(true) = process.enable_lets_encrypt {
                     formatted_toml.push(format!("enable_lets_encrypt = {}", true));
                 }
-                
+
+                if let Some(true) = process.exclude_from_start_all {
+                    formatted_toml.push(format!("exclude_from_start_all = {}", true));
+                }
                 
                 if let Some(b) = process.https {
                     formatted_toml.push(format!("https = {}", b));

--- a/src/custom_servers/directory.rs
+++ b/src/custom_servers/directory.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -96,6 +96,34 @@ pub async fn handle(
         let file_content = fs::read(&full_path)
             .map_err(|e| CustomError(format!("Failed to read file: {}", e).into()))?;
 
+        if target.render_markdown.unwrap_or_default() && full_path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+            // Convert Markdown to HTML
+            let markdown = String::from_utf8_lossy(&file_content);
+            let html = super::markdown_to_html(full_path.file_name().unwrap_or_default().to_str().unwrap_or("unnamed"),&markdown)
+                .map_err(|e| CustomError(format!("Failed to convert Markdown to HTML: {}", e).into()))?;
+
+            let response = hyper::Response::builder()
+                .status(200)
+                .header("Content-Type", "text/html; charset=utf-8")
+                .body(html.into_bytes().into())
+                .map_err(|e| CustomError(format!("Failed to create response: {}", e).into()))?;
+
+            // Cache the response
+            {
+                RESPONSE_CACHE.insert(
+                    cache_key.clone(),
+                    (
+                        "text/html; charset=utf-8".to_string(),
+                        Instant::now(),
+                        response.clone()
+                    ),
+                );
+            }
+
+            return create_simple_response_from_bytes(response);
+        }
+
+
         let mut mime_type = from_path(&full_path).first_or_octet_stream();
 
         if let Some(extension) = full_path.extension().and_then(|ext| ext.to_str()) {
@@ -129,14 +157,43 @@ pub async fn handle(
         create_simple_response_from_bytes(response)
     } else if full_path.is_dir() {
         // Check for default files before listing the directory
-        let default_files = ["index.html", "index.htm"];
+        let default_files = ["index.html", "index.htm", "index.md"];
 
         for default_file in &default_files {
             let default_file_path = full_path.join(default_file);
+
             if default_file_path.is_file() {
+
                 // Serve the default file
                 let file_content = fs::read(&default_file_path)
                     .map_err(|e| CustomError(format!("Failed to read default file: {}", e).into()))?;
+
+                if default_file_path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                    // Convert Markdown to HTML
+                    let markdown = String::from_utf8_lossy(&file_content);
+                    let html = super::markdown_to_html("Index.md",&markdown)
+                        .map_err(|e| CustomError(format!("Failed to convert Markdown to HTML: {}", e).into()))?;
+
+                    let response = hyper::Response::builder()
+                        .status(200)
+                        .header("Content-Type", "text/html; charset=utf-8")
+                        .body(html.into_bytes().into())
+                        .map_err(|e| CustomError(format!("Failed to create response: {}", e).into()))?;
+
+                    // Cache the response
+                    {
+                        RESPONSE_CACHE.insert(
+                            cache_key.clone(),
+                            (
+                                "text/html; charset=utf-8".to_string(),
+                                Instant::now(),
+                                response.clone()
+                            ),
+                        );
+                    }
+
+                    return create_simple_response_from_bytes(response);
+                }
 
                 // Guess the MIME type
                 let mime_type = from_path(&default_file_path).first_or_octet_stream();
@@ -166,105 +223,21 @@ pub async fn handle(
             }
         }
 
-        let content_in_the_directory = fs::read_dir(&full_path)
-            .map_err(|e| CustomError(format!("Failed to read directory: {}", e).into()))?;
+        // prevent listing directories if not allowed by dir server configuration
+        if target.enable_directory_browsing.unwrap_or_default() == false{
+            let response_body = "Directory browsing is disabled";
+            let response = hyper::Response::builder()
+                .status(403)
+                .header("Content-Type", "text/plain")
+                .body(response_body.into())
+                .map_err(|e| CustomError(format!("Failed to create response: {}", e).into()))?;
+    
+            return create_simple_response_from_bytes(response)
+        }    
 
-        // Build the HTML response using Cow<str>
-        let html = Cow::Borrowed(
-            r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Directory Listing</title>
-    <style>
-        body {
-            background-color: #121212;
-            color: #ffffff;
-            font-family: Arial, sans-serif;
-        }
-        a {
-            color: #1e90ff;
-            text-decoration: none;
-        }
-        a:hover {
-            text-decoration: underline;
-        }
-        ul {
-            list-style-type: none;
-        }
-        li {
-            margin: 5px 0;
-        }
-    </style>
-</head>
-<body>
-    <h1>Directory Listing for "#,
-        );
+        
+        create_index_page(&full_path, &req_path,cache_key)
 
-        // Append the requested path
-        let mut html_owned = html.into_owned();
-        html_owned.push_str(&req_path);
-        html_owned.push_str(r#"</h1>
-    <ul>"#);
-
-        // Add a link to the parent directory if not at the root
-        if req_path != "/" {
-            let parent_path = Path::new(&req_path).parent().unwrap_or(Path::new("/"));
-            let parent_path_str = parent_path.to_str().unwrap_or("/");
-            html_owned.push_str(&format!(
-                r#"<li><a href="{0}">.. (Parent Directory)</a></li>"#,
-                parent_path_str
-            ));
-        }
-
-        for entry in content_in_the_directory {
-            let entry = entry
-                .map_err(|e| CustomError(format!("Failed to read entry: {}", e).into()))?;
-            let file_name = entry
-                .file_name()
-                .into_string()
-                .unwrap_or_else(|_| "Unknown".into());
-
-            let entry_path = format!(
-                "{}/{}",
-                req_path.trim_end_matches('/'),
-                file_name
-            );
-
-            html_owned.push_str(&format!(
-                r#"<li><a href="{0}">{1}</a></li>"#,
-                entry_path,
-                file_name
-            ));
-        }
-
-        html_owned.push_str(
-            r#"
-    </ul>
-</body>
-</html>"#,
-        );
-
-      
-
-        let response = hyper::Response::builder()
-            .status(200)
-            .header("Content-Type", "text/html; charset=utf-8")
-            .body(html_owned.into_bytes().into())
-            .map_err(|e| CustomError(format!("Failed to create response: {}", e).into()))?;
-
-        // Cache the response
-        {
-            RESPONSE_CACHE.insert(
-                cache_key.clone(),
-                (
-                    "text/html; charset=utf-8".to_string(),
-                    Instant::now(),
-                    response.clone()
-                ),
-            );
-        }
-        create_simple_response_from_bytes(response)
     } else {
         // Return 404 Not Found if the path is neither a file nor a directory
         let response_body = "Not Found";
@@ -276,4 +249,216 @@ pub async fn handle(
 
         create_simple_response_from_bytes(response)
     }
+}
+
+
+// Function to format file sizes in a human-readable format
+fn format_file_size(size: u64) -> String {
+    let sizes = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = size as f64;
+    let mut i = 0;
+    while size >= 1024.0 && i < sizes.len() - 1 {
+        size /= 1024.0;
+        i += 1;
+    }
+    format!("{:.2} {}", size, sizes[i])
+}
+
+
+use std::collections::HashMap;
+
+fn create_index_page(full_path: &PathBuf, req_path: &str, cache_key: String) -> Result<EpicResponse, CustomError> {
+
+    let content_in_the_directory = fs::read_dir(&full_path)
+        .map_err(|e| CustomError(format!("Failed to read directory: {}", e).into()))?;
+
+    // Helper function to map file extensions to icons
+    fn get_icon_for_extension(extension: &str) -> &'static str {
+        let icons: HashMap<&str, &str> = [
+            ("png", "🖼️"),
+            ("jpg", "🖼️"),
+            ("jpeg", "🖼️"),
+            ("gif", "🖼️"),
+            ("bmp", "🖼️"),
+            ("txt", "📄"),
+            ("md", "📝"),
+            ("html", "🌐"),
+            ("css", "🎨"),
+            ("js", "📜"),
+            ("json", "📄"),
+            ("rs", "🦀"),
+            ("py", "🐍"),
+            ("java", "☕"),
+            ("c", "📘"),
+            ("cpp", "📘"),
+            ("cs", "💻"),
+            ("pdf", "📕"),
+            ("zip", "📦"),
+            ("tar", "📦"),
+            ("gz", "📦"),
+            ("mp3", "🎵"),
+            ("mp4", "🎥"),
+            ("wav", "🎶"),
+            ("doc", "📄"),
+            ("docx", "📄"),
+            ("xls", "📊"),
+            ("xlsx", "📊"),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        icons.get(extension).cloned().unwrap_or("📄") // Default icon if not found
+    }
+
+    // Build the HTML response
+    let html = Cow::Borrowed(
+        r#"<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Directory Listing</title>
+<style>
+    body {
+        padding: 2em;
+        background-color: #121212;
+        color: #ffffff;
+        font-family: Arial, sans-serif;
+        margin: 0;
+    }
+    a {
+        color: #1e90ff;
+        text-decoration: none;
+    }
+    a:hover {
+        text-decoration: underline;
+    }
+    ul {
+        list-style-type: none;
+        max-width: 1400px;
+        margin: 0 auto; /* Centers the element horizontally */
+        border-radius: 8px;
+        padding: 4px; /* Adds padding inside the element for inner spacing */
+        background-color: #121212;
+        background-image: 
+            linear-gradient(45deg, #ff0000, #ff7f00, #ffff00, #00ff00, #0000ff, #4b0082, #8f00ff, #ff0000);
+        background-size: 200% 200%;
+        animation: rainbowBorder 10s alternate-reverse infinite;
+        border: 4px solid transparent; /* Thick "border" effect */
+        background-clip: padding-box, border-box; /* Keeps inner padding color separate */
+    }
+    li {
+        display: flex;
+        align-items: center;
+        padding: 10px;
+        border-bottom: 1px solid #333;
+        background-color: #121212; /* Matches background for inner padding effect */
+    }
+    li:nth-child(even) {
+        background-color: #1d1d1d;
+    }
+    .icon {
+        margin-right: 10px;
+        width: 16px;
+        height: 16px;
+    }
+    .file-size {
+        margin-left: auto;
+        color: #888;
+    }
+    h1 {
+        text-align: center;
+        font-size: 1.5em;
+        margin: 20px;
+    }
+    @media (max-width: 600px) {
+        body {
+            font-size: 0.9em;
+        }
+        .file-size {
+            font-size: 0.8em;
+        }
+    }
+    /* Keyframes for smooth gradient animation */
+    @keyframes rainbowBorder {
+        0% { background-position: 0% 50%; }
+        100% { background-position: 100% 50%; }
+    }
+</style>
+
+
+
+    </head>
+    <body>
+        <h1>Directory Listing for "#,
+    );
+
+    let mut html_owned = html.into_owned();
+    html_owned.push_str(&req_path);
+    html_owned.push_str(r#"</h1>
+        <ul>"#);
+
+    // Add a link to the parent directory if not at the root
+    if req_path != "/" {
+        let parent_path = Path::new(&req_path).parent().unwrap_or(Path::new("/"));
+        let parent_path_str = parent_path.to_str().unwrap_or("/");
+        html_owned.push_str(&format!(
+            r#"<li><a href="{0}">.. (Parent Directory)</a></li>"#,
+            parent_path_str
+        ));
+    }
+
+    for entry in content_in_the_directory {
+        let entry = entry.map_err(|e| CustomError(format!("Failed to read entry: {}", e).into()))?;
+        let metadata = entry.metadata().map_err(|e| CustomError(format!("Failed to get metadata: {}", e).into()))?;
+        let file_name = entry.file_name().into_string().unwrap_or_else(|_| "Unknown".into());
+        let file_size = if metadata.is_file() {
+            format!(" ({})", format_file_size(metadata.len()))
+        } else {
+            " (Directory)".to_string()
+        };
+
+        let entry_path = format!("{}/{}", req_path.trim_end_matches('/'), file_name);
+        let icon = if metadata.is_file() {
+            let extension = file_name.rsplit('.').next().unwrap_or("");
+            get_icon_for_extension(extension)
+        } else {
+            "📁" // Folder icon
+        };
+
+        html_owned.push_str(&format!(
+            r#"<li><span class="icon">{2}</span><a href="{0}">{1}</a><span class="file-size">{3}</span></li>"#,
+            entry_path,
+            file_name,
+            icon,
+            file_size
+        ));
+    }
+
+    html_owned.push_str(
+        r#"
+        </ul>
+    </body>
+    </html>"#,
+    );
+
+    let response = hyper::Response::builder()
+        .status(200)
+        .header("Content-Type", "text/html; charset=utf-8")
+        .body(html_owned.into_bytes().into())
+        .map_err(|e| CustomError(format!("Failed to create response: {}", e).into()))?;
+
+    // Cache the response
+    {
+        RESPONSE_CACHE.insert(
+            cache_key.clone(),
+            (
+                "text/html; charset=utf-8".to_string(),
+                Instant::now(),
+                response.clone()
+            ),
+        );
+    }
+    create_simple_response_from_bytes(response)
 }

--- a/src/custom_servers/mod.rs
+++ b/src/custom_servers/mod.rs
@@ -1,1 +1,134 @@
 pub mod directory;
+
+
+pub fn markdown_to_html(title: &str, text: &str) -> Result<String, markdown::message::Message> {
+    let mut mo = markdown::Options::default();
+    mo.parse.constructs.gfm_table = true;
+    mo.parse.constructs.thematic_break = true;
+    mo.compile.allow_dangerous_html = true;
+    mo.compile.allow_dangerous_protocol = true;
+    mo.parse.constructs.code_text = true;
+    let html = markdown::to_html_with_options(&text, &mo)?;
+
+    Ok(format!(
+        r#"<!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{title}</title>
+        
+        <!-- Load initial markdown theme and syntax highlighting CSS based on user preference -->
+        <link id="theme-stylesheet" rel="stylesheet" href="">
+        <link id="syntax-stylesheet" rel="stylesheet" href="">
+
+        <style>
+        /* Base styling and theme switch */
+        :root {{
+            --font-size: 1rem;
+            --font-family: Arial, sans-serif;
+            --line-height: 1.6;
+        }}
+
+        body {{
+            font-family: var(--font-family);
+            font-size: var(--font-size);
+            line-height: var(--line-height);
+            padding: 2rem;
+            transition: background-color 0.3s, color 0.3s;
+            display: flex;
+            justify-content: center;
+        }}
+        
+        .inner-markdown {{
+            max-width: 1400px;
+            margin: 0 auto;
+            position: relative; /* Position for absolute toggle button */
+        }}
+        
+        /* Toggle Switch */
+        .theme-toggle {{
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            width: 40px;
+            height: 20px;
+            background-color: #ccc;
+            border-radius: 10px;
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            z-index: 1;
+        }}
+        .toggle-slider {{
+            position: absolute;
+            width: 16px;
+            height: 16px;
+            background-color: #333;
+            border-radius: 50%;
+            transition: transform 0.3s;
+        }}
+        .light-mode .toggle-slider {{
+            transform: translateX(2px);
+        }}
+        .dark-mode .toggle-slider {{
+            transform: translateX(22px);
+        }}
+        .light-mode pre {{
+            border: 1px solid #ddd;
+        }}
+        .dark-mode pre {{
+            border: 1px solid #333;
+        }}
+        </style>
+        <script>
+            // Set initial theme based on user preference or system setting
+            const userPrefersDark = localStorage.getItem('theme') === 'dark' || 
+                (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches);
+            const initialTheme = userPrefersDark ? 'dark' : 'light';
+            document.documentElement.classList.add(userPrefersDark ? 'dark-mode' : 'light-mode');
+
+            // Set the initial theme and syntax highlighting stylesheets
+            const themeStylesheet = document.getElementById('theme-stylesheet');
+            const syntaxStylesheet = document.getElementById('syntax-stylesheet');
+            themeStylesheet.href = `https://cdn.jsdelivr.net/gh/hyrious/github-markdown-css@main/dist/${{initialTheme}}.css`;
+            syntaxStylesheet.href = `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/${{userPrefersDark ? 'atom-one-dark' : 'github'}}.min.css`;
+
+            // Toggle theme function
+            function toggleTheme() {{
+                document.documentElement.classList.toggle('dark-mode');
+                document.documentElement.classList.toggle('light-mode');
+                const isDarkMode = document.documentElement.classList.contains('dark-mode');
+                
+                // Swap the markdown theme and syntax highlighting stylesheets based on the current theme
+                themeStylesheet.href = `https://cdn.jsdelivr.net/gh/hyrious/github-markdown-css@main/dist/${{isDarkMode ? 'dark' : 'light'}}.css`;
+                syntaxStylesheet.href = `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/${{isDarkMode ? 'atom-one-dark' : 'github'}}.min.css`;
+
+                // Store the preference
+                localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
+            }}
+        </script>
+        </head>
+        <body class='markdown-body'>
+            <div class='inner-markdown'>
+                <div class="theme-toggle" onclick="toggleTheme()">
+                    <div class="toggle-slider"></div>
+                </div>
+                {html}
+            </div>
+        
+        <!-- Load Highlight.js library -->
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js'></script>
+        <script>
+            // Apply syntax highlighting to all code blocks
+            document.querySelectorAll('code[class^="language-"]').forEach((el) => {{
+                hljs.highlightElement(el);
+            }});
+        </script>
+        </body>
+        </html>
+        "#,
+        title = title,
+        html = html,
+    ))
+}

--- a/src/init-cfg.toml
+++ b/src/init-cfg.toml
@@ -1,0 +1,40 @@
+#:schema https://raw.githubusercontent.com/OlofBlomqvist/odd-box/main/odd-box-schema-v2.1.json
+
+# ======================================================================================================
+# This is an initial odd-box configuration file, it was generated using the './odd-box --init' command.
+# It contains a very basic setup of all three types of services that odd-box can provide.
+# For simplicity, this file should be named odd-box.toml so that odd-box can find it automatically
+# when you run the './odd-box' command.  
+#
+# More information about which settings are available can be found at
+# https://github.com/OlofBlomqvist/odd-box
+# ======================================================================================================
+
+# Global settings
+version = "V2"
+ip = "127.0.0.1" 
+admin_api_port = 1234
+http_port = 8080        
+tls_port = 4343        
+
+# ======================================================================================================
+
+# This serves the directory where this file is located on the dir.localtest.me domain.
+[[dir_server]]
+host_name = "dir.localtest.me"
+dir = "$cfg_dir"
+
+# This sets up a basic reverse proxy to lobste.rs which you can reach thru the lobsters.localtest.me domain
+[[remote_target]] 
+host_name = "lobsters.localtest.me" 
+backends = [ 
+    { address = "lobste.rs", port = 443, https = true }
+]
+
+# This will spin up a python http server in the root directory of the config file (where this file is) -
+# you can reach it thru the py.localtest.me domain.
+[[hosted_process]]
+host_name = "py.localtest.me"
+bin = "python"
+auto_start = false
+args = ["-m", "http.server", "$port"] 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod proxy;
 use anyhow::bail;
 use anyhow::Context;
 use clap::Parser;
-use configuration::v2::FullyResolvedInProcessSiteConfig;use configuration::LogFormat;
+use configuration::v2::FullyResolvedInProcessSiteConfig;
 use configuration::OddBoxConfigVersion;
 use dashmap::DashMap;
 use global_state::GlobalState;
@@ -16,6 +16,9 @@ use configuration::v2::InProcessSiteConfig;
 use configuration::v2::RemoteSiteConfig;
 use configuration::OddBoxConfiguration;
 use http_proxy::ProcMessage;
+use notify::RecommendedWatcher;
+use notify::Watcher;
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tracing_subscriber::layer::SubscriberExt;
 use types::args::Args;
@@ -25,6 +28,7 @@ use types::proc_info::ProcInfo;
 use configuration::{ConfigWrapper, LogLevel};
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -126,7 +130,18 @@ pub mod global_state {
         pub async fn try_find_site(&self,pre_filter_hostname:&str) -> Option<Arc<ReverseTcpProxyTarget>> {
 
             if let Some(pt) = self.reverse_tcp_proxy_target_cache.get(pre_filter_hostname) {
-                return Some(pt.clone())
+                let (_k,v)  = pt.pair();
+                if let Some(cached_proc_id) = &v.proc_id {
+                    if let Some(_proc_info) = crate::PROC_THREAD_MAP.get(cached_proc_id) {
+                        tracing::debug!("Cache hit for {pre_filter_hostname}");
+                        return Some(v.clone());
+                    } else {
+                        tracing::trace!("Cache miss for {pre_filter_hostname} due to missing proc info");
+                    }
+                }
+                
+            } else {
+                tracing::trace!("Cache miss for {pre_filter_hostname}");
             }
 
             let mut result = None;
@@ -141,6 +156,7 @@ pub mod global_state {
                 let port = y.active_port.unwrap_or_default();
                 if port > 0 {
                     let t = ReverseTcpProxyTarget {
+                        proc_id : Some(y.get_id().clone()),
                         disable_tcp_tunnel_mode: y.disable_tcp_tunnel_mode.unwrap_or_default(),
                         remote_target_config: None, // we dont need this for hosted processes
                         hosted_target_config: Some(y.clone()),
@@ -178,6 +194,7 @@ pub mod global_state {
                     let sub_domain = filter_result.and_then(|x|x);
 
                     let t = ReverseTcpProxyTarget { 
+                        proc_id : None,
                         disable_tcp_tunnel_mode: y.disable_tcp_tunnel_mode.unwrap_or_default(),
                         hosted_target_config: None,
                         remote_target_config: Some(y.clone()),
@@ -203,6 +220,92 @@ pub mod global_state {
     
 }
 
+fn async_watcher() -> notify::Result<(RecommendedWatcher, std::sync::mpsc::Receiver<notify::Result<notify::Event>>)> {
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let watcher = <RecommendedWatcher as notify::Watcher>::new(
+        move |res| {
+            tx.send(res).unwrap();
+        },
+        notify::Config::default(),
+    )?;
+
+    Ok((watcher, rx))
+}
+
+lazy_static! {
+    static ref RELOADING_CONFIGURATION : tokio::sync::Semaphore = tokio::sync::Semaphore::new(1);
+} 
+
+
+async fn config_file_monitor(
+    config: Arc<RwLock<ConfigWrapper>>, 
+    global_state: Arc<GlobalState>
+) -> anyhow::Result<()> {
+    
+    let guard = config.read().await;
+    let cfg_path = guard.path.clone().expect("odd-box must be using a configuration file.");
+    drop(guard);
+
+    let (mut watcher, rx) = async_watcher()?;
+    
+    watcher.watch(Path::new(&cfg_path), notify::RecursiveMode::Recursive)?;
+    
+    loop {
+
+        let exit_requested_clone = &global_state.app_state.exit;
+        
+        if exit_requested_clone.load(Ordering::Relaxed) {
+            break;
+        }
+
+        match rx.try_recv() {
+            Ok(Err(e)) => {
+                tracing::warn!("Error while watching config file: {e:?}");
+            }
+            Ok(Ok(e)) => {
+                
+                
+                if RELOADING_CONFIGURATION.available_permits() == 0 {
+                    continue;
+                }
+
+                let _permit = RELOADING_CONFIGURATION.acquire().await.unwrap();
+
+                match e.kind {
+                    notify::EventKind::Modify(notify::event::ModifyKind::Data(_)) => {
+                            match crate::configuration::reload::reload_from_disk(global_state.clone()).await {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    tracing::error!("Failed to reload configuration file: {e:?}");
+                                }
+                            }
+                    },
+                    notify::EventKind::Remove(_remove_kind) => {
+                        tracing::error!("Configuration file was removed. This is not supported. Please restart odd-box.");
+                    
+                    },
+                    _ => {},
+                }
+
+            },
+            Err(e) => {
+                match e {
+                    std::sync::mpsc::TryRecvError::Empty => {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    },
+                    std::sync::mpsc::TryRecvError::Disconnected => {
+                        tracing::error!("Config file watcher channel disconnected. This is a bug in odd-box.");
+                        break;
+                    }
+                }
+            },
+        }
+    }
+
+    Ok(())
+}
+
 async fn thread_cleaner() {
     let liveness_token = Arc::new(true);
     crate::BG_WORKER_THREAD_MAP.insert("The Janitor".into(), BgTaskInfo {
@@ -210,47 +313,62 @@ async fn thread_cleaner() {
         status: "Managing active tasks..".into()
     }); 
     loop {
-        // crate::BG_WORKER_THREAD_MAP
-        //     .get_mut("The Janitor")
-        //     .and_then(|mut guard| {
-        //         guard.value_mut().status = "Cleaning".into();
-        //         Some(())
-        //     });
-        PROC_THREAD_MAP.retain(|_k,v| v.liveness_ptr.upgrade().is_some());
-        BG_WORKER_THREAD_MAP.retain(|_k,v| v.liveness_ptr.upgrade().is_some());
-        tokio::time::sleep(Duration::from_secs(1)).await
+        {
+            PROC_THREAD_MAP.retain(|_k,v| v.liveness_ptr.upgrade().is_some());
+            BG_WORKER_THREAD_MAP.retain(|_k,v| v.liveness_ptr.upgrade().is_some());
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await
     }
 }
 
-fn generate_config(file_name:&str, fill_example:bool) -> anyhow::Result<()> {
 
+
+fn generate_config(file_name:Option<&str>, fill_example:bool) -> anyhow::Result<crate::configuration::v2::OddBoxV2Config> {
     let current_working_dir = std::env::current_dir()?;
-    let file_path = current_working_dir.join(file_name);
-
-    if std::path::Path::exists(std::path::Path::new(file_name)) {
-        return Err(anyhow::anyhow!(format!("File already exists: {file_path:?}")));
+    if let Some(file_name) = file_name {
+        let current_working_dir = std::env::current_dir()?;
+        let file_path = current_working_dir.join(file_name);
+        if std::path::Path::exists(std::path::Path::new(file_name)) {
+            return Err(anyhow::anyhow!(format!("File already exists: {file_path:?}")));
+        }
     }
-
-    let mut cfg = crate::configuration::v2::OddBoxV2Config::example();
-    
     if fill_example == false {
-        cfg.hosted_process = None;
-        cfg.remote_target = None;
-        cfg.env_vars = vec![];
-        cfg.alpn = None;
-        cfg.admin_api_port = None;
-        cfg.auto_start = None;
-        cfg.http_port = None;
-        cfg.tls_port = None;
-        cfg.ip = None;
-        cfg.log_level = None;
-        cfg.default_log_format = LogFormat::standard;
-    }
+        let mut init_cfg = include_str!("./init-cfg.toml").to_string();
 
-    let serialized = cfg.to_string()?;
-    std::fs::write(&file_path, serialized)?;
-    tracing::info!("Configuration file written to {file_path:?}");
-    return Ok(())
+        if cfg!(target_os = "macos") {
+            // mac os allows for binding to lower ports without root, so we can use the default ports.
+            // notably it only allows it when binding to 0.0.0.0 so we need to change the ip to
+            init_cfg = init_cfg
+                .replace("ip = \"127.0.0.1\" ","ip = \"0.0.0.0\" ")
+                .replace("tls_port = \"4343\" ","ip = \"443\" ")
+                .replace("http_port = \"8080\" ","ip = \"80\" ");
+        }
+          
+        let cfg = configuration::OddBoxConfig::parse(&init_cfg).map_err(|e| {
+            anyhow::anyhow!(format!("Failed to parse initial configuration: {e}"))
+        })?;
+        match cfg {
+            configuration::OddBoxConfig::V2(parsed_config) => {
+                if let Some(file_name) = file_name {
+                    let file_path = current_working_dir.join(file_name);
+                    std::fs::write(&file_path, init_cfg)?;
+                    tracing::info!("Configuration file written to {file_path:?}");    
+                }
+                return Ok(parsed_config)
+            },
+            _ => {
+                return Err(anyhow::anyhow!("Failed to parse initial configuration"))
+            }
+        }
+    }     
+    let cfg = crate::configuration::v2::OddBoxV2Config::example();
+    if let Some(file_name) = file_name {
+        let serialized = cfg.to_string()?;
+        let file_path = current_working_dir.join(file_name);
+        std::fs::write(&file_path, serialized)?;
+        tracing::info!("Configuration file written to {file_path:?}");
+    }
+    return Ok(cfg)
 
 }
 
@@ -342,10 +460,10 @@ async fn main() -> anyhow::Result<()> {
     let tui_flag = args.tui.unwrap_or(true);
 
     if args.generate_example_cfg {
-        generate_config("odd-box-example-config.toml",true)?;
+        generate_config(Some("odd-box-example-config.toml"),true)?;
         return Ok(())
     } else if args.init {
-        generate_config("odd-box.toml",false)?;
+        generate_config(Some("odd-box.toml"),false)?;
         return Ok(())
     }
 
@@ -435,7 +553,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Spawn thread cleaner (removes dead threads from the proc_thread_map)
-    tokio::spawn(thread_cleaner());
+    let cleanup_thread = tokio::spawn(thread_cleaner());
+    let cfg_monitor = tokio::spawn(config_file_monitor(shared_config.clone(),global_state.clone()));
    
     let mut tui_task : Option<JoinHandle<()>> = None;
 
@@ -533,8 +652,10 @@ async fn main() -> anyhow::Result<()> {
         _ = tt.await;
     // otherwise we will wait for the exit signal set by ctrl-c
     } else {
+        
+        tracing::info!("odd-box started successfully. use ctrl-c to quit.");
         while global_state.app_state.exit.load(Ordering::Relaxed) == false {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
     }
 
@@ -585,7 +706,7 @@ async fn main() -> anyhow::Result<()> {
         } else {
             i+=1;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
  
     if tui_flag {
@@ -597,8 +718,10 @@ async fn main() -> anyhow::Result<()> {
     }
 
     _ = proxy_thread.abort();
-    _ = proxy_thread.await;
- 
+    _ = proxy_thread.await; 
+    _ = cfg_monitor.abort();
+    _ = cleanup_thread.abort();
+
 
     if tui_flag {
         println!("odd-box exited successfully");

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,8 +340,8 @@ fn generate_config(file_name:Option<&str>, fill_example:bool) -> anyhow::Result<
             // notably it only allows it when binding to 0.0.0.0 so we need to change the ip to
             init_cfg = init_cfg
                 .replace("ip = \"127.0.0.1\" ","ip = \"0.0.0.0\" ")
-                .replace("tls_port = \"4343\" ","ip = \"443\" ")
-                .replace("http_port = \"8080\" ","ip = \"80\" ");
+                .replace("tls_port = 4343","tls_port = 443")
+                .replace("http_port = 8080","http_port = 80");
         }
           
         let cfg = configuration::OddBoxConfig::parse(&init_cfg).map_err(|e| {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -375,6 +375,9 @@ async fn handle_new_tcp_stream(
                         }
                 }
             }
+            else {
+                tracing::trace!("We do not have any site configured for '{target}' that allows tcp tunnelling.. will use terminating proxy instead.");
+            }
         },
         
         // we see that this is tls data, and we expect tls data, and we also extracted a hostname by peeking.

--- a/src/tcp_proxy/tcp.rs
+++ b/src/tcp_proxy/tcp.rs
@@ -9,6 +9,7 @@ use std::{
 use crate::configuration::v2::BackendFilter;
 use crate::global_state::GlobalState;
 use crate::tcp_proxy::tls::client_hello::TlsClientHello;
+use crate::types::proc_info::ProcId;
 use crate::types::proxy_state::{ProxyActiveConnection, ProxyActiveConnectionType};
 use tokio::net::TcpStream;
 use tracing::*;
@@ -29,7 +30,8 @@ pub struct ReverseTcpProxyTarget {
     pub forward_wildcard: bool,
     // subdomain is filled in otf upon receiving a request for this target and there is a subdomain used in the req
     pub sub_domain: Option<String> ,
-    pub disable_tcp_tunnel_mode : bool
+    pub disable_tcp_tunnel_mode : bool,
+    pub proc_id : Option<ProcId>,
 }
 
 

--- a/src/tests/configuration.rs
+++ b/src/tests/configuration.rs
@@ -150,3 +150,13 @@ use crate::configuration::OddBoxConfiguration;
 
 }
 
+
+#[test] 
+fn init_cfg_is_valid() {
+    crate::generate_config(None,false).expect("should be able to create initial config");
+}
+
+#[test]
+fn init_filled_cfg_is_valid() { 
+    crate::generate_config(None,true).expect("should be able to create initial filled config");
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -103,6 +103,8 @@ pub async fn run(
     ).collect();
 
     
+    tracing::info!("odd-box started successfully");
+    
     // TUI event loop
     let tui_handle = {
         let terminal = Arc::clone(&terminal);

--- a/src/tui/threads_widget.rs
+++ b/src/tui/threads_widget.rs
@@ -20,12 +20,13 @@ pub fn draw(
         return
     }
 
-    let headers = [ "Task", "Child PID", "Current Status"];
+    let headers = [ "Task","#Id","Child PID", "Current Status"];
     
     let mut rows : Vec<Vec<String>> =  crate::PROC_THREAD_MAP.iter().map(|guard| {
         let (_thread_id, thread_info) = guard.pair();
         vec![
             format!("[PROC_HOST] {}",thread_info.config.host_name),
+            format!("{}",thread_info.config.proc_id.id),
             format!("{}",thread_info.pid.as_ref().map_or(String::new(),|x|x.to_string())),
             format!("selected port: {:?}", thread_info.config.active_port)
         ]
@@ -84,9 +85,10 @@ pub fn draw(
     tui_state.threads_tab_state.scroll_state.total_rows = rows.len();
 
     let widths = [
-        Constraint::Min(50), 
-        Constraint::Min(20), 
-        Constraint::Percentage(100)       
+        Constraint::Min(10), 
+        Constraint::Min(10), 
+        Constraint::Min(10), 
+        Constraint::Min(10),   
     ];
     
     

--- a/src/types/proc_info.rs
+++ b/src/types/proc_info.rs
@@ -11,13 +11,17 @@ impl ProcId {
     pub fn new() -> Self {
         Self { id: uuid::Uuid::new_v4().to_string() }
     }
+    pub fn from(id:&str) -> Self {
+        Self { id: id.to_string() }
+    }
 }
 
 #[derive(Debug)]
 pub struct ProcInfo {
     pub liveness_ptr : Weak<AtomicBool>,
     pub config : FullyResolvedInProcessSiteConfig,
-    pub pid : Option<String>
+    pub pid : Option<String>,
+    pub marked_for_removal : bool
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR adds initial support for hot-reload of the configuration. Not pretty but seems to work well enough..

Removing most custom hot-patching logic from the API methods and instead just write to disk, triggering the new reload logic.

Additionally also includes minor changes to the dir server indexing and styling.
