### PR TITLE
Use ip for procs test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "odd-box"
-version = "0.1.10"
+version = "0.1.10-Anders1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -1345,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1390,21 +1390,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "odd-box"
-version = "0.1.10-Anders1"
+version = "0.1.11-alpha1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "odd-box"
 description = "a dead simple reverse proxy server and web server"
-version = "0.1.10-Anders1"
+version = "0.1.11-alpha1"
 edition = "2021"
 authors = ["Olof Blomqvist <olof@twnet.se>"]
 repository = "https://github.com/OlofBlomqvist/odd-box"
@@ -23,7 +23,7 @@ axum-extra = { version = "0.9.3", features = ["typed-header"] }
 # === PROXY ====================================================
 dirs = "5.0.1"
 schemars = { version = "0.8.21", features = ["chrono"] }
-futures-util = "0.3.30"
+futures-util = "0.3.31"
 hyper = { version = "1.4.1" , features=["http2","client","server"] }
 hyper-util = { version = "0.1.7", features = ["full"] }
 regex = "1.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "odd-box"
 description = "a dead simple reverse proxy server and web server"
-version = "0.1.10"
+version = "0.1.10-Anders1"
 edition = "2021"
 authors = ["Olof Blomqvist <olof@twnet.se>"]
 repository = "https://github.com/OlofBlomqvist/odd-box"

--- a/odd-box-schema-v3.0.json
+++ b/odd-box-schema-v3.0.json
@@ -142,6 +142,13 @@
       "format": "uint16",
       "minimum": 0.0
     },
+    "use_loopback_ip_for_procs": {
+      "description": "Uses 127.0.0.1 instead of localhost when proxying to locally hosted processes.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "version": {
       "description": "The schema version - you do not normally need to set this, it is set automatically when you save the configuration.",
       "allOf": [
@@ -382,6 +389,14 @@
           "type": "string"
         },
         "https": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "keep_original_host_header": {
+          "description": "Defaults to true.",
+          "default": true,
           "type": [
             "boolean",
             "null"

--- a/src/configuration/v3.rs
+++ b/src/configuration/v3.rs
@@ -94,7 +94,11 @@ pub struct InProcessSiteConfig {
     /// If you wish to set a specific loglevel for this hosted process.
     /// Defaults to "Info".
     /// If this level is lower than the global log_level you will get the message elevated to the global log level instead but tagged with the actual log level.
-    pub log_level: Option<LogLevel>
+    pub log_level: Option<LogLevel>,
+
+    #[serde(default = "true_option")]
+    /// Defaults to true.
+    pub keep_original_host_header: Option<bool>
 }
 impl InProcessSiteConfig {
     pub fn set_id(&mut self,id:ProcId){
@@ -420,6 +424,9 @@ pub struct OddBoxV3Config {
     /// Used for securing the admin api and web-interface. If you do not set this, anyone can access the admin api.
     pub odd_box_password: Option<String>,
 
+    /// Uses 127.0.0.1 instead of localhost when proxying to locally hosted processes. 
+    pub use_loopback_ip_for_procs: Option<bool>
+
 }
 
 
@@ -661,6 +668,7 @@ impl crate::configuration::OddBoxConfiguration<OddBoxV3Config> for OddBoxV3Confi
     }
     fn example() -> OddBoxV3Config {
         OddBoxV3Config {
+            use_loopback_ip_for_procs: None,
             odd_box_password: None,
             odd_box_url: None,
             dir_server: None,
@@ -680,6 +688,7 @@ impl crate::configuration::OddBoxConfiguration<OddBoxV3Config> for OddBoxV3Confi
             port_range_start: 4200,
             hosted_process: Some(vec![
                 InProcessSiteConfig {
+                    keep_original_host_header: None,
                     log_level: None,
                     enable_lets_encrypt: Some(false),
                     proc_id: ProcId::new(),
@@ -797,6 +806,7 @@ impl TryFrom<super::v2::OddBoxV2Config> for OddBoxV3Config{
 
     fn try_from(old_config: super::v2::OddBoxV2Config) -> Result<Self, Self::Error> {
         let new_config = Self {
+            use_loopback_ip_for_procs: None,
             odd_box_password: None,
             odd_box_url: None,
             dir_server: None,
@@ -829,6 +839,7 @@ impl TryFrom<super::v2::OddBoxV2Config> for OddBoxV3Config{
                 let new_hints = if new_hints.len() == 0 { None } else { Some(new_hints) };
 
                 InProcessSiteConfig {
+                    keep_original_host_header: None,
                     log_level: None,
                     enable_lets_encrypt: Some(false),
                     proc_id: ProcId::new(),

--- a/src/configuration/v3.rs
+++ b/src/configuration/v3.rs
@@ -296,8 +296,17 @@ impl InProcessSiteConfig {
             }
         };
 
+
+        let local_addr = {
+            if state.config.read().await.use_loopback_ip_for_procs.unwrap_or_default() {
+                "127.0.0.1"
+            } else {
+                "localhost"
+            }
+        };
+
         let backends = vec![Backend {
-            address: "localhost".to_string(), // we are always connecting to localhost since we are the ones hosting this process
+            address: local_addr.to_string(), // we are always connecting to localhost since we are the ones hosting this process
             port: port,
             https: self.https,
             hints: self.hints.clone(),

--- a/src/http_proxy/service.rs
+++ b/src/http_proxy/service.rs
@@ -517,11 +517,17 @@ async fn handle_http_request(
             port,
             original_path_and_query
         );
+
+        let local_addr = if configuration.use_loopback_ip_for_procs.unwrap_or_default() {
+            "127.0.0.1"
+        } else {
+            "localhost"
+        };
         
         // we add the host flag manually in proxy method, this is only to avoid dns lookup for local targets.
         // todo: opt in/out via cfg (?)
         let skip_dns_for_local_target_url = format!("{scheme}://{}:{}{}",
-            "localhost",
+            local_addr,
             port,
             original_path_and_query
         );
@@ -533,7 +539,7 @@ async fn handle_http_request(
         let backend = crate::configuration::Backend {
             hints: hints,
             // we are hosting this service so clearly it is local
-            address: "localhost".to_string(),
+            address: local_addr.to_string(),
             port: port,
             https: Some(enforce_https)
         };

--- a/src/http_proxy/utils.rs
+++ b/src/http_proxy/utils.rs
@@ -114,11 +114,12 @@ pub async fn proxy(
                 host_header_to_use = Some(req_host_name.to_string());
             }
         },
-        Target::Proc(_cfg) => {
-            host_header_to_use = Some(req_host_name.to_string());
+        Target::Proc(cfg) => {
+            if cfg.keep_original_host_header.unwrap_or_default() {
+                host_header_to_use = Some(req_host_name.to_string());
+            }            
         }
     };
-
 
     let hints = backend.hints.clone().unwrap_or_default();
     
@@ -327,7 +328,7 @@ fn create_proxied_request<B>(
     let target_uri = target_url.parse::<http::Uri>()
         .map_err(|e| ProxyError::InvalidUri(e))?;
     *request.uri_mut() = target_uri;
-    
+
     
     // we want to pass the original host header to the backend (the one that the client requested)
     // and not the one we are connecting to as that might as well just be an internal name or IP.

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,11 @@ pub mod global_state {
 
             let mut result = None;
             let cfg = self.config.read().await;
-
+            let local_addr = if cfg.use_loopback_ip_for_procs.unwrap_or_default() {
+                "127.0.0.1"
+            } else {
+                "localhost"
+            };
             for guard in &cfg.docker_containers {
                 let (host_name,x) = guard.pair();
                 //let host_name = x.host_name_label.unwrap_or(format!("{}.odd-box.localhost",x.container_name));
@@ -215,7 +219,7 @@ pub mod global_state {
                             // use dns name to avoid issues where hyper uses ipv6 for 127.0.0.1 since tcp tunnel mode uses ipv4.
                             // not keeping them the same means the target backend will see different ip's for the same client
                             // and possibly invalidate sessions in some cases.
-                            address: "localhost".to_string(), //y.host_name.to_owned(), // --- configurable
+                            address:  local_addr.to_string(), //y.host_name.to_owned(), // --- configurable
                             https: y.https,
                             port: y.active_port.unwrap_or_default()
                         }],

--- a/src/main.rs
+++ b/src/main.rs
@@ -702,22 +702,22 @@ async fn main() -> anyhow::Result<()> {
     tokio::task::spawn(docker_thread(global_state.clone()));
 
     
-    // if on a released/stable version, we notify the user when there is a later stable version
-    // available for them to update to. current_is_latest will not include any -rc,-pre or -dev releases
-    // and so we wont run this unless user is also on stable.
-    if !self_update::current_version().contains("-") {
-        match self_update::current_is_latest().await {
-            Err(e) => {
-                tracing::warn!("It was not possible to retrieve information regarding the latest available version of odd-box: {e:?}");
-            },
-            Ok(Some(v)) => {
-                tracing::info!("There is a newer version of odd-box available - please consider upgrading to {v:?}. For unmanaged installations you can run 'odd-box --update' otherwise see your package manager for upgrade instructions.");
-            },
-            Ok(None) => {
-                tracing::info!("You are running the latest version of odd-box :D");
-            }
-        }
-    }
+    // // if on a released/stable version, we notify the user when there is a later stable version
+    // // available for them to update to. current_is_latest will not include any -rc,-pre or -dev releases
+    // // and so we wont run this unless user is also on stable.
+    // if !self_update::current_version().contains("-") {
+    //     match self_update::current_is_latest().await {
+    //         Err(e) => {
+    //             tracing::warn!("It was not possible to retrieve information regarding the latest available version of odd-box: {e:?}");
+    //         },
+    //         Ok(Some(v)) => {
+    //             tracing::info!("There is a newer version of odd-box available - please consider upgrading to {v:?}. For unmanaged installations you can run 'odd-box --update' otherwise see your package manager for upgrade instructions.");
+    //         },
+    //         Ok(None) => {
+    //             tracing::info!("You are running the latest version of odd-box :D");
+    //         }
+    //     }
+    // }
 
 
     // if in tui mode, we can just hang around until the tui thread exits.

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -39,14 +39,14 @@ pub async fn update() -> anyhow::Result<()> {
 pub fn current_version() -> &'static str { cargo_crate_version!() }
 
 /// returns Some(newer_version) or None if current is latest.
-pub async fn current_is_latest() -> anyhow::Result<Option<String>> {
-    let current_version = current_version();
-    match find_latest_version(false).await {
-        Ok(v) if current_version != v => Ok(Some(v)),
-        Ok(_) => Ok(None),
-        Err(e) => Err(e)
-    }
-}
+// pub async fn current_is_latest() -> anyhow::Result<Option<String>> {
+//     let current_version = current_version();
+//     match find_latest_version(false).await {
+//         Ok(v) if current_version != v => Ok(Some(v)),
+//         Ok(_) => Ok(None),
+//         Err(e) => Err(e)
+//     }
+// }
 
 
 pub async fn find_latest_version(include_pre:bool) -> anyhow::Result<String> {


### PR DESCRIPTION
support for using 127.0.0.1 instead of localhost as hostname for locally hosted processes..

- adds global prop:

`use_loopback_ip_for_procs = Option<bool> (default false)`

- adds proc prop:

`keep_original_host_header = Option<bool> (default true)`


(**note** - unrelated change included: this pr also removes the message regarding outdated version as it did not work very well)
